### PR TITLE
In build environment use translate instead

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
   ],
   "devDependencies": {
     "qunit": "~1.15.0",
-    "system.js": "~0.10.1"
+    "system.js": "~0.16.6",
+	"es6-module-loader": "~0.16.3"
   },
   "resolutions": {
     "traceur": "0.0.58"

--- a/json.js
+++ b/json.js
@@ -3,30 +3,72 @@
   Provides the JSON module format definition.
 */
 function _SYSTEM_addJSON(loader) {
-
 	var jsonTest = /^[\s\n\r]*[\{\[]/;
+	var jsonExt = /\.json$/i;
+	var jsExt = /\.js$/i;
+	var inNode = typeof window === "undefined";
+
+	// Add the extension to _extensions so that it can be cloned.
+	loader._extensions.push(_SYSTEM_addJSON);
+
+	// if someone has a moduleName that is .json, make sure it loads a json file
+	// no matter what paths might do
+	var loaderLocate = loader.locate;
+	loader.locate = function(load){
+	  return loaderLocate.apply(this, arguments).then(function(address){
+		if(jsonExt.test(load.name)) {
+			return address.replace(jsExt, "");
+		}
+
+	    return address;
+	  });
+	};
+
+	// If we are in a build we should convert to CommonJS instead.
+	if(inNode) {
+		var loaderTranslate = loader.translate;
+		loader.translate = function(load){
+			if(jsonExt.test(load.name)) {
+				var parsed = parse(load);
+				if(parsed) {
+					return "def" + "ine([], function(){\n" +
+						"\treturn " + load.source + "\n});";
+				}
+			}
+
+			return loaderTranslate.call(this, load);
+		};
+		return;
+	}
+
 	var loaderInstantiate = loader.instantiate;
 	loader.instantiate = function(load) {
 		var loader = this,
 			parsed;
 
-		if ( (load.metadata.format === 'json' || !load.metadata.format) && jsonTest.test(load.source)  ) {
-		  
-			try {
-				parsed = JSON.parse(load.source);
-			} catch(e) {}
-			if(parsed) {
-				load.metadata.format = 'json';
+		parsed = parse(load);
+		if(parsed) {
+			load.metadata.format = 'json';
 
-				load.metadata.execute = function(){
-					return parsed;
-				};
-			}
+			load.metadata.execute = function(){
+				return parsed;
+			};
 		}
+
 		return loaderInstantiate.call(loader, load);
 	};
 
 	return loader;
+
+	// Attempt to parse a load as json.
+	function parse(load){
+		if ( (load.metadata.format === 'json' || !load.metadata.format) && jsonTest.test(load.source)  ) {
+			try {
+				return JSON.parse(load.source);
+			} catch(e) {}
+		}
+
+	}
 }
 
 if (typeof System !== "undefined") {

--- a/json.js
+++ b/json.js
@@ -4,41 +4,31 @@
 */
 function _SYSTEM_addJSON(loader) {
 
-  // if someone has a moduleName that is .json, make sure it loads a json file
-  // no matter what paths might do
-  //var loaderLocate = loader.locate;
-  //loader.locate = function(load){
-  //  return loaderLocate.apply(this, arguments).then(function(address){
-  //    return address;
-  //  });
-  //};
-  var jsonTest = /^[\s\n\r]*[\{\[]/;
-  var loaderInstantiate = loader.instantiate;
-  loader.instantiate = function(load) {
-    var loader = this,
-        parsed;
+	var jsonTest = /^[\s\n\r]*[\{\[]/;
+	var loaderInstantiate = loader.instantiate;
+	loader.instantiate = function(load) {
+		var loader = this,
+			parsed;
 
-    if ( (load.metadata.format === 'json' || !load.metadata.format) && jsonTest.test(load.source)  ) {
-      
-      try{
-        parsed = JSON.parse(load.source);
-      } catch(e) {}
-      if(parsed) {
-        load.metadata.format = 'json';
+		if ( (load.metadata.format === 'json' || !load.metadata.format) && jsonTest.test(load.source)  ) {
+		  
+			try {
+				parsed = JSON.parse(load.source);
+			} catch(e) {}
+			if(parsed) {
+				load.metadata.format = 'json';
 
-	      load.metadata.execute = function(){
-	        return parsed;
-	      };
-      }
-      
+				load.metadata.execute = function(){
+					return parsed;
+				};
+			}
+		}
+		return loaderInstantiate.call(loader, load);
+	};
 
-    }
-    return loaderInstantiate.call(loader, load);
-  };
-
-  return loader;
+	return loader;
 }
 
 if (typeof System !== "undefined") {
-  _SYSTEM_addJSON(System);
+	_SYSTEM_addJSON(System);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@
 QUnit.module("system-json plugin");
 
 asyncTest("Basics works", function(){
-	System.paths["test/my.json"] = "test/my.json";
 	System.import("test/my.json").then(function(my){
 		equal(my.name, "foo", "name is right");
 	}).then(start);


### PR DESCRIPTION
In a build environment we are going to translate to AMD rather than use
the instantiate hook. Fixes #1
