### PR TITLE
Allow transformation of JSON

### DIFF
--- a/json.js
+++ b/json.js
@@ -24,6 +24,12 @@ function _SYSTEM_addJSON(loader) {
 	  });
 	};
 
+	var transform = function(loader, load, data){
+		var fn = loader.jsonOptions && loader.jsonOptions.transform;
+		if(!fn) return data;
+		return fn.call(loader, load, data);
+	};
+
 	// If we are in a build we should convert to CommonJS instead.
 	if(inNode) {
 		var loaderTranslate = loader.translate;
@@ -31,8 +37,9 @@ function _SYSTEM_addJSON(loader) {
 			if(jsonExt.test(load.name)) {
 				var parsed = parse(load);
 				if(parsed) {
+					parsed = transform(this, load, parsed);
 					return "def" + "ine([], function(){\n" +
-						"\treturn " + load.source + "\n});";
+						"\treturn " + JSON.stringify(parsed) + "\n});";
 				}
 			}
 
@@ -48,6 +55,7 @@ function _SYSTEM_addJSON(loader) {
 
 		parsed = parse(load);
 		if(parsed) {
+			parsed = transform(loader, load, parsed);
 			load.metadata.format = 'json';
 
 			load.metadata.execute = function(){

--- a/test/another.json
+++ b/test/another.json
@@ -1,0 +1,4 @@
+{
+	"name": "foo",
+	"priv": "PRIVATE"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -8,5 +8,20 @@ asyncTest("Basics works", function(){
 	}).then(start);
 });
 
+QUnit.module("jsonOptions");
+
+asyncTest("transform allows you to transform the json object", function(){
+	System.jsonOptions = {
+		transform: function(load, data){
+			delete data.priv;
+			return data;
+		}
+	};
+
+	System.import("test/another.json").then(function(a){
+		ok(!a.priv, "Private field excluded");
+	}).then(start);
+});
+
 
 QUnit.start();


### PR DESCRIPTION
This defines a new API, System.jsonOptions.transform that allows a user
to transform the JSON object. This is needed in cases where JSON might
contain private information that cannot be deployed to a production
environment.
